### PR TITLE
fix exception when e has no property of url

### DIFF
--- a/main.js
+++ b/main.js
@@ -47,6 +47,10 @@ let include = [
 
 // 匹配URL
 function matchUrl(e) {
+	if (e.url === undefined) {
+		console.log("不是合法的地址，无法代理：" + JSON.stringify(e))
+		return false;
+	}
 	console.log("开始访问：" + JSON.stringify(e))
     for (var key in include) {
         let item = include[key]


### PR DESCRIPTION
我没有详细了解这个e所有可能的场景，但有时会报e.url是undefined（我本地已经修复了就不贴报错信息了），加了个判断避免报错。